### PR TITLE
[fix] do not hardcode themes stream

### DIFF
--- a/learn2-git-sync.yaml
+++ b/learn2-git-sync.yaml
@@ -16,5 +16,5 @@ streams:
      type: ReadOnlyStream
      prefixes:
        '':
-       - user/themes/learn2-git-sync
-       - user/themes/learn2
+       - themes://learn2-git-sync
+       - themes://learn2


### PR DESCRIPTION
In case of multisite setup, hardcoding the path to the themes would prevent any site-specific customization, as they would rely on the themes stored in `user/themes`.