### PR TITLE
Remove tab characters from comment indent

### DIFF
--- a/learn2-git-sync.yaml
+++ b/learn2-git-sync.yaml
@@ -1,5 +1,5 @@
 enabled: true
-root_page: 					                                # optional: set root page of documentation
+root_page:                                          # optional: set root page of documentation
 top_level_version: false                            # Use versions for top level navigation
 google_analytics_code:                              # Enter your `UA-XXXXXXXX-X` code here
 home_url:                                           # http://getgrav.org


### PR DESCRIPTION
Indent the comment with spaces instead of tabs as on some systems the tab characters prevent the theme from being loaded