### PR TITLE
Updating Google Analytic placeholder code

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -122,7 +122,7 @@ form:
     google_analytics_code:
         type: text
         label: Google Analytics Code
-        placeholder: UA-XXXXXXXX-X
+        placeholder: G-XXXXXXXXXX
         validate:
           type: text
 

--- a/learn2-git-sync.yaml
+++ b/learn2-git-sync.yaml
@@ -1,7 +1,7 @@
 enabled: true
 root_page:                                          # optional: set root page of documentation
 top_level_version: false                            # Use versions for top level navigation
-google_analytics_code:                              # Enter your `UA-XXXXXXXX-X` code here
+google_analytics_code:                              # Enter your `G-XXXXXXXXXX` code here
 home_url:                                           # http://getgrav.org
 github:
     position: top                                   # top | bottom | off


### PR DESCRIPTION
- Google's Universal analytics will be deprecated in July 2023, therefore UA-XXXXXXXX-X will no longer be used. This update changes the placeholder to the upcoming GA4. Follows https://github.com/getgrav/grav-theme-learn2/pull/103